### PR TITLE
Move schedule to separate page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ c4sponsorsUrl: "/assets/GDG_DevFest_Partnership.pdf"
 navigationLinks:
  - {permalink: "/", text: "Home"}
  # - {permalink: "/blog/", text: "Blog"}
- # - {permalink: "/schedule/", text: "Schedule"}
+ - {permalink: "/schedule/", text: "Schedule"}
  - {permalink: "/speakers/", text: "Speakers"}
  # - {permalink: "/team/", text: "Team"}
  # - {permalink: "/logistics/", text: "Logistics"}

--- a/index.html
+++ b/index.html
@@ -12,8 +12,6 @@ modal: all
 
  {% include rockstar-speakers.html %}
 
- {% include schedule.html %}
-
  {% include partners.html %}
 
  {% include subscribe.html %}


### PR DESCRIPTION
Removed schedule directly injected to landing page content. Added menu item with schedule for opening schedule in a separate page.